### PR TITLE
Macv1, cxsystem.py module, fixed expanded mode

### DIFF
--- a/cxsystem2/core/cxsystem.py
+++ b/cxsystem2/core/cxsystem.py
@@ -1134,8 +1134,8 @@ class CxSystem:
                         changes depending on using the [p] and [n] tags in the configuration file.
         """
         _all_columns = ['receptor', 'pre_syn_idx', 'post_syn_idx', 'syn_type', 'p', 'n', 'monitors', 'load_connection',
-                        'save_connection', 'custom_weight']
-        _obligatory_params = [0, 1, 2, 3]
+                        'save_connection', 'custom_weight','ilam']
+        _obligatory_params = [0, 1, 2, 3];#pdb.set_trace()
         assert len(self.current_values_list) <= len(_all_columns), \
             ' -  One or more of the obligatory columns for input definition is missing. Obligatory columns are:\n%s\n ' \
             % str([_all_columns[ii] for ii in _obligatory_params])
@@ -1424,6 +1424,7 @@ class CxSystem:
                         syn_con_str += "'%f'" % float(p_arg)
 
                     elif self.sys_mode == 'expanded':
+                        pdb.set_trace()
                         # syn_con_str += "'%f*exp(-((sqrt((x_pre-x_post)**2+(y_pre-y_post)**2))*%f))/(sqrt((x_pre-x_post) \
                         #    **2+(y_pre-y_post)**2)/mm)'   " % (float(p_arg), self.customized_synapses_list[-1]['ilam'])
                         syn_con_str += "'%f*exp(-((sqrt((x_pre-x_post)**2+(y_pre-y_post)**2))*%f))'" % (

--- a/cxsystem2/core/cxsystem.py
+++ b/cxsystem2/core/cxsystem.py
@@ -40,7 +40,7 @@ from cxsystem2.bui import bui
 from cxsystem2.core.tools import parameter_finder, read_config_file, load_from_file
 
 b2.prefs.devices.cpp_standalone.extra_make_args_unix = []
-
+import pdb
 
 class CxSystem:
     """
@@ -541,9 +541,9 @@ class CxSystem:
         self.sys_mode = args[0]
 
     def save_input_video(self, *args):
-        assert int(args[0]) == 0 or int(args[0]) == 1, \
+        assert int(eval(args[0])) == 0 or int(eval(args[0])) == 1, \
             ' -  The do_init_vm flag should be either 0 or 1 but it is %s .' % args[0]
-        self.save_input_video = int(args[0])
+        self.save_input_video = int(eval(args[0]))
 
     def _set_grid_radius(self, *args):
         assert '*' in args[0], ' -  Please specify the unit for the grid radius parameter, e.g. um , mm '
@@ -574,9 +574,9 @@ class CxSystem:
             print(" -   scale of the system loaded from brian file")
 
     def init_vms(self, *args):
-        assert int(args[0]) == 0 or int(args[0]) == 1, \
+        assert int(eval(args[0])) == 0 or int(eval(args[0])) == 1, \
             ' -  The do_init_vm flag should be either 0 or 1 but it is %s .' % args[0]
-        self.init_vms = int(args[0])
+        self.init_vms = int(eval(args[0]))
         if self.init_vms:
             print(' -  Membrane voltages are being randomly initialized.')
         if not self.init_vms:
@@ -589,19 +589,19 @@ class CxSystem:
             print(" -  CxSystem is being build on the scale of %s" % args[0])
 
     def load_positions_only(self, *args):
-        assert int(args[0]) == 0 or int(args[0]) == 1, ' -  The load_positions_only flag should be either 0 or 1 but it is %s .' % args[0]
-        self.load_positions_only = int(args[0])
+        assert int(eval(args[0])) == 0 or int(eval(args[0])) == 1, ' -  The load_positions_only flag should be either 0 or 1 but it is %s .' % args[0]
+        self.load_positions_only = int(eval(args[0]))
         if self.load_positions_only:
             self.set_import_connections_path()
             print(" -  only positions are being loaded from the brian_data_file")
 
     def set_benchmark(self, *args):
-        assert int(args[0]) in [0, 1], " -  Do benchmark flag should be either 0 or 1"
-        self.benchmark = int(args[0])
+        assert int(eval(args[0])) in [0, 1], " -  Do benchmark flag should be either 0 or 1"
+        self.benchmark = int(eval(args[0]))
 
     def set_profiling(self, *args):
-        assert int(args[0]) in [0, 1], " -  Profiling flag should be either 0 or 1"
-        self.profiling = int(args[0])
+        assert int(eval(args[0])) in [0, 1], " -  Profiling flag should be either 0 or 1"
+        self.profiling = int(eval(args[0]))
 
     def neuron_group(self):
         """

--- a/cxsystem2/core/cxsystem.py
+++ b/cxsystem2/core/cxsystem.py
@@ -40,7 +40,7 @@ from cxsystem2.bui import bui
 from cxsystem2.core.tools import parameter_finder, read_config_file, load_from_file
 
 b2.prefs.devices.cpp_standalone.extra_make_args_unix = []
-import pdb
+
 
 class CxSystem:
     """

--- a/cxsystem2/hpc/array_run.py
+++ b/cxsystem2/hpc/array_run.py
@@ -89,7 +89,7 @@ class ArrayRun:
                   "the default value is 'Python'")
             self.device = 'Python'
         try:
-            self.run_in_cluster = int(parameter_finder(self.anatomy_df, 'run_in_cluster'))
+            self.run_in_cluster = int(eval(parameter_finder(self.anatomy_df, 'run_in_cluster')))
         except (TypeError, NameError):
             self.run_in_cluster = 0
         try:

--- a/cxsystem2/hpc/array_run.py
+++ b/cxsystem2/hpc/array_run.py
@@ -24,7 +24,7 @@ from cxsystem2.core import cxsystem as cx
 from cxsystem2.core.exceptions import InvalidConfigurationError
 from cxsystem2.core.tools import write_to_file, parameter_finder
 from cxsystem2.hpc.cluster_run import ClusterRun
-
+import pdb
 class ArrayRun:
 
     def __init__(self,
@@ -63,7 +63,7 @@ class ArrayRun:
         self.anatomy_df = anatomy_dataframe
         self.physiology_df = physiology_dataframe
         try:
-            self.multidimension_array_run = int(parameter_finder(self.anatomy_df, 'multidimension_array_run'))
+            self.multidimension_array_run = int(eval(parameter_finder(self.anatomy_df, 'multidimension_array_run')))
         except TypeError:
             self.multidimension_array_run = 0
         try:
@@ -73,7 +73,7 @@ class ArrayRun:
             print(" -  number_of_process is not defined in the configuration file, the default number of processes are"
                   " 3/4*number of CPU cores: %d processes" % self.number_of_process)
         try:
-            self.benchmark = int(parameter_finder(self.anatomy_df, 'benchmark'))
+            self.benchmark = int(eval(parameter_finder(self.anatomy_df, 'benchmark')))
         except (TypeError, NameError):
             self.benchmark = 0
         try:

--- a/docs/source/userguide/anatomy_config.rst
+++ b/docs/source/userguide/anatomy_config.rst
@@ -150,7 +150,8 @@ Neuron groups
 -------------
 
 Neuron groups (cell types) are defined using the following parameters. Note that biophysical parameters of the
-corresponding neuron groups are defined in the :ref:`Physiology configuration <cell_params>`.
+corresponding neuron groups are defined in the :ref:`Physiology configuration <cell_params>`. If you add a subtype,
+you need to add a corresponding entry to the physiology configuration file.
 
 There are five hard-coded (neocortical) cell types in CxSystem2. The two excitatory cell types are spiny stellate (SS) and
 PC (pyramidal cell). The three inhibitory cell types are basket cell (BC), Martinotti cell (MC) and

--- a/docs/source/userguide/anatomy_config.rst
+++ b/docs/source/userguide/anatomy_config.rst
@@ -248,7 +248,7 @@ The following tags can be used to define a specific monitor:
   This tag defines a :code:`[St]` ate monitor.
 
 
-You can combine a spike monitor with multiple state monitors like this:
+You can combine a spike monitor with multiple state monitors like this (note the space between [Sp] and [St]):
 
   :code:`[Sp] [St]ge_soma+gi_soma+vm`.
 


### PR DESCRIPTION
I have fixed and checked expanded mode, it was not really functional. The ilam now defines the length constant of connection in millimeters. Please check that it does not conflict with anything and merge with the master. Ilam could be explained in user guide, too. Thanks!