### PR TITLE
Fix batch simulations

### DIFF
--- a/cxsystem2/core/cxsystem.py
+++ b/cxsystem2/core/cxsystem.py
@@ -2100,12 +2100,7 @@ class CxSystem:
                     "%s.delay=%s['delay']" % (_dyn_syn_name, _dyn_syn_namespace_name),
                     locals=sys._getframe().f_locals,
                 )
-
-            setattr(self.main_module, _dyn_syn_name, eval(_dyn_syn_name))
-            try:
-                setattr(self.Cxmodule, _dyn_syn_name, eval(_dyn_syn_name))
-            except AttributeError:
-                pass
+            setattr(self.Cxmodule, _dyn_syn_name, eval(_dyn_syn_name))
 
             self.monitors(monitors.split(" "), _dyn_syn_name)
 

--- a/cxsystem2/core/cxsystem.py
+++ b/cxsystem2/core/cxsystem.py
@@ -3069,6 +3069,7 @@ class CxSystem:
                     self.current_parameters_s == "input_spikes_filename"
                 ].index.item()
             ]
+            # TODO: the following call looks for input files in the output folder. It fails unless input files have already been copied to the output folder   
             spikes_data = load_from_file(
                 self.workspace.get_simulation_folder().joinpath(input_spikes_filename)
             )

--- a/cxsystem2/core/cxsystem.py
+++ b/cxsystem2/core/cxsystem.py
@@ -6,6 +6,7 @@ import multiprocessing
 import os
 import platform
 import shutil
+import subprocess
 import sys
 import threading
 import time
@@ -359,23 +360,33 @@ class CxSystem:
                 with open(tmp_physio_path2, "w") as f:
                     json.dump(physiology_config, f)
                 physiology_config = tmp_physio_path2
-            # this is vulnerable to code injection
-            if sys.platform == "linux":
-                # Local
-                from cxsystem2.hpc.array_run import ArrayRun
 
-                # When in cluster, here you run the individual parameter set. The tmp_anat_path and tmp_physio_path are dataframes with correct params.
-                ArrayRun(
+            if sys.platform == "linux":
+                stdout_arg = (
+                    "None"
+                    if self.array_run_stdout_file is None
+                    else str(self.array_run_stdout_file)
+                )
+                command = [
+                    sys.executable,
+                    array_run_path,
                     tmp_anat_path,
                     tmp_physio_path,
-                    suffix,
-                    int(cluster_run_start_idx),
-                    int(cluster_run_step),
-                    anatomy_and_system_config,
-                    physiology_config,
-                    cluster_flag,
-                    self.array_run_stdout_file,
-                )
+                    str(suffix),
+                    str(int(cluster_run_start_idx)),
+                    str(int(cluster_run_step)),
+                    str(anatomy_and_system_config),
+                    str(physiology_config),
+                    str(cluster_flag),
+                    stdout_arg,
+                ]
+                try:
+                    subprocess.run(command, check=True)
+                except subprocess.CalledProcessError as exc:
+                    raise RuntimeError(
+                        f"array_run.py failed with exit code {exc.returncode}"
+                    ) from exc
+                
             else:
                 command = "python {array_run} {anat_df} {physio_df} {suffix} {start} {step} {anat_path} {physio_path} {cluster} {stdout_file}".format(
                     array_run=array_run_path,


### PR DESCRIPTION
Since CxSystem2 minimum supported python version was raised to 3.14 (424f7ea), batch simulations result in a RuntimeError. The reasons are detailed at the end of the PR. Solved by isolating each run in the batch within a subprocess.

Also includes some minor fixes.

53 tests passing, 1 skipped. 


Detailed description: the first run in the batch was able to launch a process just fine; only on the second one it failed. The problem arose when CxSystem2 upgraded from python 3.12 to 3.14 a while ago. Before python 3.14, on Linux, creating child processes with multiprocessing (which is needed in batch runs) was based on "fork", while from python 3.14 onwards it's based on "forkserver". "fork" basically created another process from a parent process as soon as it was requested, by copying the state of the first (parent) into the second (child). This meant that any child process would have all the parent's python objects in memory. The class ArrayRun lacks multiprocessing-safe import behavior, but with "fork" it could run anyway. With python 3.14, "forkserver" is stricter. The first process starts the bootstrap logic, but the second call cannot simply "copy" the old state from parent to child as it did with "fork": due to "forkserver" rules, the child interpreter re-imports the main module, re-executing code all the way down to ArrayRun. ArrayRun tries to start multiprocessing again but it finds python in the middle of bootstrapping the first process. This leads to a recursive situation, where RuntimeError is raised. In summary, with python 3.14 the assumptions on which ArrayRun was based are no longer valid. A small fix that avoids extensive refactoring is to create a subprocess for each call to ArrayRun.